### PR TITLE
updated node-sass dependency to 4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,6 @@
   },
   "dependencies": {
     "css": "^2.2.1",
-    "node-sass": "^3.6.0"
+    "node-sass": "^4.5.3"
   }
 }


### PR DESCRIPTION
the new (4.x) node-sass has pre-built binaries for alpine-linux.