### PR TITLE
The loader works incorrectly when a property name has multiple hyphens

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -19,7 +19,7 @@ var getDeclarationProperty = function getDeclarationProperty(property) {
     propertyCharacters = propertyCharacters.map(function (char, index) {
         return propertyCharacters[index - 1] === '-' ? char.toUpperCase() : char;
     });
-    return propertyCharacters.join('').replace('-', '');
+    return propertyCharacters.join('').replace(/\-/g, '');
 };
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -11,7 +11,7 @@ const getDeclarationProperty = function( property )
   propertyCharacters = propertyCharacters.map( ( char, index ) => {
       return propertyCharacters[ index - 1 ] === '-' ? char.toUpperCase() : char;
   } );
-  return propertyCharacters.join( '' ).replace( '-', '' );
+  return propertyCharacters.join( '' ).replace(/\-/g, '' );
 }
 
 /**


### PR DESCRIPTION
The loader replaced only the first hyphen.
For example `-webkit-border-radius` was converted to `Webkit-Border-Radius` instead of expected `WebkitBorderRadius`